### PR TITLE
Ignore undefined column values when spreading records

### DIFF
--- a/src/sql.ts
+++ b/src/sql.ts
@@ -23,10 +23,15 @@ function escapeIdentifier(identifier: string) {
 }
 
 function objectEntries<T extends { [key: string]: Value }, Value = any>(
-  object: T
+  object: T,
+  filterUndefinedValues?: boolean
 ): Array<[string, Value]> {
   const keys = Object.keys(object)
-  return keys.map(key => [key, object[key]] as [string, Value])
+  const entries = keys.map(key => [key, object[key]] as [string, Value])
+
+  return filterUndefinedValues
+    ? entries.filter(([, columnValue]) => typeof columnValue !== "undefined")
+    : entries
 }
 
 function serializeSqlTemplateExpression(expression: any, nextParamID: number): QueryConfig {
@@ -171,7 +176,7 @@ function buildSpreadUpdateFragment(
  * const { rows } = await database.query(sql`SELECT * FROM users WHERE ${spreadAnd({ name: "John", email: "john@example.com" })}`)
  */
 export function spreadAnd(record: any): SqlSpecialExpressionValue {
-  const values = objectEntries<any>(record)
+  const values = objectEntries<any>(record, true)
   return {
     type: $sqlExpressionValue,
     buildFragment(nextParamID: number) {
@@ -186,7 +191,7 @@ export function spreadAnd(record: any): SqlSpecialExpressionValue {
  * await database.query(sql`INSERT INTO users ${spreadInsert({ name: "John", email: "john@example.com" })}`)
  */
 export function spreadInsert(record: any): SqlSpecialExpressionValue {
-  const insertionValues = objectEntries<any>(record)
+  const insertionValues = objectEntries<any>(record, true)
   return {
     type: $sqlExpressionValue,
     buildFragment(nextParamID: number) {
@@ -201,7 +206,7 @@ export function spreadInsert(record: any): SqlSpecialExpressionValue {
  * await database.query(sql`UPDATE users SET ${spreadUpdate({ name: "John", email: "john@example.com" })} WHERE id = 1`)
  */
 export function spreadUpdate(record: any): SqlSpecialExpressionValue {
-  const values = objectEntries<any>(record)
+  const values = objectEntries<any>(record, true)
   return {
     type: $sqlExpressionValue,
     buildFragment(nextParamID: number) {

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -27,7 +27,8 @@ test("spreadAnd() works", t => {
     SELECT * FROM users WHERE ${spreadAnd({
       name: "Hugo",
       age: 20,
-      email: sql.raw("'foo@example.com'")
+      email: sql.raw("'foo@example.com'"),
+      foo: undefined
     })}
   `),
     dedentQueryConfig({
@@ -43,7 +44,8 @@ test("spreadInsert() works", t => {
     INSERT INTO users ${spreadInsert({
       name: "Hugo",
       age: 20,
-      created_at: sql.raw("NOW()")
+      created_at: sql.raw("NOW()"),
+      foo: undefined
     })} RETURNING *
   `),
     dedentQueryConfig({
@@ -59,7 +61,8 @@ test("spreadUpdate() works", t => {
     UPDATE users SET ${spreadUpdate({
       name: "Hugo",
       age: 20,
-      created_at: sql.raw("NOW()")
+      created_at: sql.raw("NOW()"),
+      foo: undefined
     })}
   `),
     dedentQueryConfig({


### PR DESCRIPTION
For any `spread*()` call's record parameter: Ignore properties whose value is `undefined`.