### PR TITLE
Make it possible to add multiple rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,18 @@ const users = await database.query(sql`
 // sql`INSERT INTO users ("name", "email") VALUES ('John', 'john@example.com')`
 ```
 
+```js
+const users = await database.query(sql`
+  INSERT INTO users ${spreadInsert(
+    { name: "John", email: "john@example.com" },
+    { name: "Travis", email: "travis@example.com" }
+  )}
+`)
+
+// same as:
+// sql`INSERT INTO users ("name", "email") VALUES ('John', 'john@example.com'), ('Travis', 'travis@example.com')`
+```
+
 ### spreadUpdate({ [columnName: string]: any })
 
 Spread INSERT VALUES to keep the query sweet and short without losing explicity.

--- a/dist/sql.d.ts
+++ b/dist/sql.d.ts
@@ -1,6 +1,9 @@
 import { QueryConfig, SqlSpecialExpressionValue } from "./internals";
 export { QueryConfig };
 declare type PgQueryConfig = QueryConfig;
+interface ValueRecord<T = any> {
+    [key: string]: T;
+}
 /**
  * SQL template string tag. Returns a query object: `{ text: string, values: any[] }`.
  * Template expressions are automatically SQL-injection-proofed unless wrapped in `sql.raw()`.
@@ -35,7 +38,7 @@ export declare function spreadAnd(record: any): SqlSpecialExpressionValue;
  * @example
  * await database.query(sql`INSERT INTO users ${spreadInsert({ name: "John", email: "john@example.com" })}`)
  */
-export declare function spreadInsert(record: any): SqlSpecialExpressionValue;
+export declare function spreadInsert(...records: ValueRecord[]): SqlSpecialExpressionValue;
 /**
  * Convenience function to keep UPDATE statements concise. Takes an object:
  * @example

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -55,6 +55,37 @@ test("spreadInsert() works", t => {
   )
 })
 
+test("spreadInsert() works with multiple inserts", t => {
+  t.deepEqual(
+    dedentQueryConfig(sql`
+    INSERT INTO users ${spreadInsert(
+      {
+        name: "Hugo",
+        age: 20,
+        created_at: sql.raw("NOW()"),
+        foo: undefined
+      },
+      {
+        age: 25,
+        name: "Jon",
+        foo: undefined,
+        created_at: sql.raw("NOW()")
+      },
+      {
+        bar: 1,
+        age: 27,
+        name: "Hans",
+        created_at: null
+      }
+    )} RETURNING *
+  `),
+    dedentQueryConfig({
+      text: `INSERT INTO users ("name", "age", "created_at") VALUES ($1, $2, NOW()), ($3, $4, NOW()), ($5, $6, $7) RETURNING *`,
+      values: ["Hugo", 20, "Jon", 25, "Hans", 27, null]
+    })
+  )
+})
+
 test("spreadUpdate() works", t => {
   t.deepEqual(
     dedentQueryConfig(sql`


### PR DESCRIPTION
Make it possible to add multiple rows in one query:
```ts
sql`INSERT INTO users ${spreadInsert({
    name: "Hugo",
    age: 20,
    created_at: sql.raw("NOW()")
  }, {
    age: 25,
    name: "Jon",
    created_at: sql.raw("NOW()")
  }, {
    age: 27,
    name: "Hans",
    created_at: null
  })} RETURNING *`

// Text: INSERT INTO users ("name", "age", "created_at") VALUES ($1, $2, NOW()), ($3, $4, NOW()), ($5, $6, $7) RETURNING *
// Value: [ "Hugo", 20, "Jon", 25, "Hans", 27 ]
```

### Limitation:

Typescript will accept the following:
```ts
sql`INSERT INTO users ${spreadInsert({
    name: "Hugo",
    age: 20
  }, {
    title: "Mr",
    surname: "Jonson"
  })} RETURNING *`
```

It will however be a run time error: `TypeError: Missing value for column "name"`. I don't see any other solution.

An other issue is the following. Let's say to try to run the following code:
```ts
sql`INSERT INTO users ${spreadInsert({
    name: "Hugo",
    age: 20,
    surname: "Jonson"
  }, {
    name: "Jon",
    age: 25
  })} RETURNING *`
```

Right now we are getting the error `Error: Rows must be of the same length` which could be nice (but it might be better to give the error: `TypeError: Missing value for column "surname"` instead).

And we are getting the same error for the following code:
```ts
sql`INSERT INTO users ${spreadInsert({
    name: "Hugo",
    age: 20
  }, {
    name: "Jon",
    age: 25,
    surname: "Jonson"
  })} RETURNING *`
```

But we are also getting the same error for the following snippet:
```ts
sql`INSERT INTO users ${spreadInsert({
    name: "Hugo",
    age: 20
  }, {
    name: "Jon",
    age: 25,
    foo: undefined
  })} RETURNING *`
```

We could give better errors messages in these scenarios but that would also add some overhead. Is it worth it? We need to filter out all `undefined` values.

Also this is currently not supported: 
```ts
sql`INSERT INTO users ${spreadInsert({
    name: "Hugo",
    age: 20
  }, {
    ['"name"']: "Jon", // The column name must be exactly the same for all rows
    age: 25,
  })} RETURNING *`
``` 
Instead we are getting the following error: `TypeError: Missing value for column "name"`

I would say that these are acceptable limitations but I want to hear your input.

Closing #19 