### PR TITLE
Export ColumnDescription interface

### DIFF
--- a/dist/schema.d.ts
+++ b/dist/schema.d.ts
@@ -12,7 +12,7 @@ export declare enum ColumnType {
 interface ObjectShape {
     [propName: string]: ColumnDescription<any, any, any, any>;
 }
-interface ColumnDescription<Type extends ColumnType, SubType extends ColumnDescription<any, any, any, any>, EnumValues extends string | number, ObjectProps extends ObjectShape> {
+export interface ColumnDescription<Type extends ColumnType, SubType extends ColumnDescription<any, any, any, any>, EnumValues extends string | number, ObjectProps extends ObjectShape> {
     type: Type;
     subtype?: SubType;
     enum?: EnumValues[];

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -16,7 +16,7 @@ interface ObjectShape {
   [propName: string]: ColumnDescription<any, any, any, any>
 }
 
-interface ColumnDescription<
+export interface ColumnDescription<
   Type extends ColumnType,
   SubType extends ColumnDescription<any, any, any, any>,
   EnumValues extends string | number,


### PR DESCRIPTION
Fixes `Exported variable has or is using name 'ColumnDescription' from external module, but cannot be named` error in TypeScript.