### PR TITLE
uuid column type added

### DIFF
--- a/dist/schema.d.ts
+++ b/dist/schema.d.ts
@@ -7,7 +7,8 @@ export declare enum ColumnType {
     JSON = "json",
     Number = "number",
     Object = "object",
-    String = "string"
+    String = "string",
+    UUID = "uuid"
 }
 interface ObjectShape {
     [propName: string]: ColumnDescription<any, any, any, any>;
@@ -75,6 +76,10 @@ interface SchemaTypes {
     /** Data type for CHAR, VARCHAR, TEXT columns. */
     String: {
         type: ColumnType.String;
+    };
+    /** Data type for Uuid */
+    UUID: {
+        type: ColumnType.UUID;
     };
     /** Data type for array columns. Pass the data type of the array elements. */
     Array<SubType extends ColumnDescription<any, any, any, any>>(subtype: SubType): ColumnDescription<ColumnType.Array, SubType, any, any>;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -9,7 +9,8 @@ export enum ColumnType {
   JSON = "json",
   Number = "number",
   Object = "object",
-  String = "string"
+  String = "string",
+  UUID = "uuid"
 }
 
 interface ObjectShape {
@@ -118,6 +119,9 @@ interface SchemaTypes {
   /** Data type for CHAR, VARCHAR, TEXT columns. */
   String: { type: ColumnType.String }
 
+  /** Data type for Uuid */
+  UUID: { type: ColumnType.UUID }
+
   /** Data type for array columns. Pass the data type of the array elements. */
   Array<SubType extends ColumnDescription<any, any, any, any>>(
     subtype: SubType
@@ -161,6 +165,7 @@ export const Schema: SchemaTypes = {
   Date: { type: ColumnType.Date },
   Number: { type: ColumnType.Number },
   String: { type: ColumnType.String },
+  UUID: { type: ColumnType.UUID },
 
   Array<SubType extends ColumnDescription<any, any, any, any>>(elementType: SubType) {
     return { type: ColumnType.Array, subtype: elementType }

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -7,6 +7,7 @@ test("can define a schema", t => {
       id: Schema.Number,
       email: Schema.String,
       email_confirmed: Schema.Boolean,
+      uuid: Schema.UUID,
       profile: Schema.JSON(
         Schema.Object({
           avatar_url: Schema.String,


### PR DESCRIPTION
I use the uuid column type in postgres. This change allows for the definition of a uuid column. Will update with corresponding change in postguard. https://github.com/andywer/postguard/pull/36